### PR TITLE
Add schema for credit endpoint and tests and changed types to decimal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "3.7.1"
 install:
   - pip install -e .[test]
 script:

--- a/ledger/accounting.py
+++ b/ledger/accounting.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from sqlalchemy.orm.exc import NoResultFound
 
 from ledger.accounting_types import (
@@ -10,22 +12,16 @@ from ledger import models
 
 class LedgerEntry:
 
-    def __init__(self, account_number: str, amount: int, accounting_type: AbstractEntryType):
+    def __init__(self, account_number: str, amount: Decimal, accounting_type: AbstractEntryType):
         self.account_number = account_number
         self.amount = amount
         self.accounting_type = accounting_type
 
-    def get_signed_amount(self) -> int:
+    def get_signed_amount(self) -> Decimal:
         return self.amount * self.accounting_type.get_sign()
 
-    def get_accounting_type_code(self) -> int:
+    def get_accounting_type_code(self) -> str:
         return self.accounting_type.get_type_code()
-
-    def __str__(self) -> str:
-        return (
-            f"<LedgerEntry: account_number={self.account_number}, "
-            f"amount={self.amount}, accounting_type={self.accounting_type}>"
-        )
 
 
 class Balance:
@@ -45,7 +41,7 @@ class Balance:
         return balance_entry
 
     @staticmethod
-    def get_for_account(account_number: str) -> int:
+    def get_for_account(account_number: str) -> Decimal:
         balance_record = Balance._get_or_create_record(account_number)
         return balance_record.balance
 
@@ -67,7 +63,7 @@ class Ledger:
     """
 
     @classmethod
-    def add_entry(cls, account_number: str, amount: int, type_code: TypeCode) -> LedgerEntry:
+    def add_entry(cls, account_number: str, amount: Decimal, type_code: TypeCode) -> LedgerEntry:
         accounting_type = get_accounting_type(type_code)
         ledger_entry = LedgerEntry(account_number, amount, accounting_type)
         cls._store(ledger_entry)

--- a/ledger/controllers.py
+++ b/ledger/controllers.py
@@ -1,9 +1,10 @@
 from http import HTTPStatus
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, jsonify, request
 
 from ledger.accounting import Balance, Ledger
 from ledger.accounting_types import TypeCode
+from ledger.schemas import credit_schema, ledger_entry_schema, debit_schema, balance_schema
 
 
 blueprint = Blueprint("ledger",  __name__, url_prefix="/")
@@ -13,33 +14,46 @@ blueprint = Blueprint("ledger",  __name__, url_prefix="/")
 def credit():
     if request.method == "POST":
         post_data = request.get_json()
-        credit_amount = post_data['creditAmount']
-        account_number = post_data['accountNumber']
+        result = credit_schema.load(post_data).data
 
-        entry = Ledger.add_entry(account_number, credit_amount, TypeCode.CREDIT)
-        return str(entry), HTTPStatus.CREATED
+        entry = Ledger.add_entry(
+            result.account_number,
+            result.amount,
+            TypeCode.CREDIT,
+        )
+        serialized_entry = ledger_entry_schema.dump(entry)
+        return jsonify(serialized_entry.data), HTTPStatus.CREATED
 
 
 @blueprint.route("/ledger/debit", methods=("POST",))
 def debit():
     if request.method == "POST":
         post_data = request.get_json()
-        debit_amount = post_data["debitAmount"]
-        account_number = post_data["accountNumber"]
+        result = debit_schema.load(post_data).data
 
-        entry = Ledger.add_entry(account_number, debit_amount, TypeCode.DEBIT)
-        return str(entry), HTTPStatus.CREATED
+        entry = Ledger.add_entry(
+            account_number=result.account_number,
+            amount=result.amount,
+            type_code=TypeCode.DEBIT,
+        )
+        serialized_entry = ledger_entry_schema.dump(entry)
+        return jsonify(serialized_entry.data), HTTPStatus.CREATED
 
 
 @blueprint.route("/ledger", methods=("GET",))
 def ledger():
     if request.method == "GET":
         entries = Ledger.get_all_entries()
-        return jsonify([str(entry) for entry in entries])
+        response = []
+        for entry in entries:
+            serialized_entry = ledger_entry_schema.dump(entry)
+            response.append(serialized_entry.data)
+        return jsonify(response), HTTPStatus.OK
 
 
 @blueprint.route("/account/<account_number>/balance", methods=("GET",))
 def account_balance(account_number):
     if request.method == "GET":
         balance = Balance.get_for_account(account_number)
-        return jsonify({"balance": balance})
+        serialized_entry = balance_schema.dump({"balance": balance})
+        return jsonify(serialized_entry.data), HTTPStatus.OK

--- a/ledger/models.py
+++ b/ledger/models.py
@@ -1,4 +1,3 @@
-from ledger.accounting_types import TypeCode
 from ledger.database import db
 
 
@@ -15,7 +14,7 @@ class Ledger(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     account_number = db.Column(db.String(16))
-    amount = db.Column(db.Integer)
+    amount = db.Column(db.DECIMAL(10, 2))
     accounting_type = db.Column(db.String(1))
 
     def __repr__(self):
@@ -31,7 +30,7 @@ class Balance(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     account_number = db.Column(db.String(16), index=True, unique=True)
-    balance = db.Column(db.Integer)
+    balance = db.Column(db.DECIMAL(10, 2))
 
     def __repr__(self):
         return (

--- a/ledger/schemas.py
+++ b/ledger/schemas.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+from marshmallow import Schema, fields, post_load
+
+
+class LedgerEntrySchema(Schema):
+    """For serializing a LedgerEntry for responses."""
+    accountNumber = fields.Str(
+        attribute="account_number",
+    )
+    accountingType = fields.Str(
+        attribute="accounting_type",
+    )
+    amount = fields.Str(
+        attribute="amount",
+    )
+
+
+@dataclass
+class TransactionData:
+    """Deserialized credit/debit request."""
+    amount: Decimal
+    account_number: str
+
+
+class CreditSchema(Schema):
+    creditAmount = fields.Decimal(
+        attribute="amount",
+        required=True,
+    )
+    accountNumber = fields.Str(
+        attribute="account_number",
+        required=True,
+    )
+
+    @post_load
+    def create_credit_data(self, data) -> TransactionData:
+        return TransactionData(**data)
+
+    class Meta:
+        strict = True
+
+
+class DebitSchema(Schema):
+    debitAmount = fields.Decimal(
+        attribute="amount",
+        required=True,
+    )
+    accountNumber = fields.Str(
+        attribute="account_number",
+        required=True,
+    )
+
+    @post_load
+    def create_debit_data(self, data) -> TransactionData:
+        return TransactionData(**data)
+
+    class Meta:
+        strict = True
+
+
+class BalanceSchema(Schema):
+    balance = fields.Str()
+
+
+ledger_entry_schema = LedgerEntrySchema()
+credit_schema = CreditSchema()
+debit_schema = DebitSchema()
+balance_schema = BalanceSchema()

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,12 @@ application_dependencies = [
     'flask-sqlalchemy',
     'psycopg2',
     'flask-migrate',
+    'marshmallow',
 ]
 prod_dependencies = []
 test_dependencies = [
     'tox',
+    'pytest',
     'pytest-cov',
     'pytest-env',
     'pytest-flask-sqlalchemy',

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from ledger.accounting import Ledger, Balance
@@ -11,12 +13,12 @@ from ledger.accounting_types import TypeCode, get_accounting_type
 def test_add_accounting_type_to_ledger(db_session, type_code, type_str):
     entry = Ledger.add_entry(
         account_number="39209030",
-        amount=1230,
+        amount=Decimal("1230.00"),
         type_code=type_code,
     )
     assert len(Ledger.get_all_entries()) == 1
     assert entry.account_number == "39209030"
-    assert entry.amount == 1230
+    assert entry.amount == Decimal("1230.00")
     assert str(entry.accounting_type) == type_str
 
 
@@ -24,19 +26,19 @@ def test_balance_is_updated(db_session):
     account_number = "39209030"
     Ledger.add_entry(
         account_number=account_number,
-        amount=1230,
+        amount=Decimal("1230.00"),
         type_code=TypeCode.CREDIT,
     )
-    assert Balance.get_for_account(account_number) == 1230
+    assert Balance.get_for_account(account_number) == Decimal("1230.00")
     Ledger.add_entry(
         account_number=account_number,
-        amount=382,
+        amount=Decimal("382.00"),
         type_code=TypeCode.DEBIT,
     )
-    assert Balance.get_for_account(account_number) == 848
+    assert Balance.get_for_account(account_number) == Decimal("848.00")
     Ledger.add_entry(
         account_number=account_number,
-        amount=921,
+        amount=Decimal("921.00"),
         type_code=TypeCode.CREDIT,
     )
-    assert Balance.get_for_account(account_number) == 1769
+    assert Balance.get_for_account(account_number) == Decimal("1769.00")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from ledger.accounting_types import TypeCode
@@ -7,7 +9,7 @@ from ledger.models import Ledger, Balance
 def test_ledger_save_method(db_session):
     entry = Ledger(
         account_number="12323123",
-        amount=392,
+        amount=Decimal("392.00"),
         accounting_type=TypeCode.CREDIT.value,
     )
     entry.save()
@@ -18,7 +20,7 @@ def test_ledger_save_method(db_session):
 def test_balance_save_method(db_session):
     entry = Balance(
         account_number="234234423",
-        balance=23424,
+        balance=Decimal("23424.93"),
     )
     entry.save()
     assert len(Balance.query.filter_by(account_number="234234423").all()) == 1
@@ -28,15 +30,15 @@ def test_balance_save_method(db_session):
 def test_ledger_representation(db_session):
     entry = Ledger(
         account_number="12323123",
-        amount=392,
+        amount=Decimal("392.82"),
         accounting_type=TypeCode.DEBIT.value,
     )
-    assert str(entry) == "<Ledger: (id=None, account_number=12323123, amount=392, accounting_type=D)>"
+    assert str(entry) == "<Ledger: (id=None, account_number=12323123, amount=392.82, accounting_type=D)>"
 
 
 def test_balance_representation(db_session):
     entry = Balance(
         account_number="234234423",
-        balance=23424,
+        balance=Decimal("23424.93"),
     )
-    assert str(entry) == "<Balance: (id=None, account_number=234234423, balance=23424)>"
+    assert str(entry) == "<Balance: (id=None, account_number=234234423, balance=23424.93)>"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,144 @@
+from decimal import Decimal
+
+import pytest
+from marshmallow import ValidationError
+
+from ledger.accounting import LedgerEntry
+from ledger.accounting_types import credit_type, debit_type
+from ledger.schemas import credit_schema, ledger_entry_schema, debit_schema, balance_schema
+
+
+class TestLedgerEntrySchema:
+    schema = ledger_entry_schema
+
+    def test_serializing_object_with_valid_credit_type(self):
+        ledger_entry = LedgerEntry(
+            account_number="12345678",
+            accounting_type=credit_type,
+            amount=Decimal("1283.92"),
+        )
+        serialized_data = self.schema.dump(ledger_entry).data
+        assert serialized_data["accountNumber"] == "12345678"
+        assert serialized_data["accountingType"] == "Credit"
+        assert serialized_data["amount"] == "1283.92"
+
+    def test_serializing_object_with_valid_debit_type(self):
+        ledger_entry = LedgerEntry(
+            account_number="399383902",
+            accounting_type=debit_type,
+            amount=Decimal("827.81"),
+        )
+        serialized_data = self.schema.dump(ledger_entry).data
+        assert serialized_data["accountNumber"] == "399383902"
+        assert serialized_data["accountingType"] == "Debit"
+        assert serialized_data["amount"] == "827.81"
+
+
+class TestCreditSchema:
+    schema = credit_schema
+
+    def test_deserializing_object_with_valid_data(self):
+        data = {
+            "creditAmount": "120.32",
+            "accountNumber": "93929393",
+        }
+        result = self.schema.load(data).data
+        assert result.amount == Decimal("120.32")
+        assert result.account_number == "93929393"
+
+    def test_missing_account_number_raises_validation_error(self):
+        data = {
+            "creditAmount": "383.20"
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "accountNumber" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["accountNumber"]
+
+    def test_missing_credit_amount_raises_validation_error(self):
+        data = {
+            "accountNumber": "93929393",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "creditAmount" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["creditAmount"]
+
+    def test_missing_all_fields_raises_validation_error(self):
+        data = {}
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "accountNumber" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["accountNumber"]
+        assert "creditAmount" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["creditAmount"]
+
+    def test_additional_fields_are_ignored(self):
+        data = {
+            "creditAmount": "120.32",
+            "accountNumber": "93929393",
+            "additionalField": "value",
+        }
+        result = self.schema.load(data).data
+        assert result.amount == Decimal("120.32")
+        assert result.account_number == "93929393"
+
+
+class TestDebitSchema:
+    schema = debit_schema
+
+    def test_deserializing_object_with_valid_data(self):
+        data = {
+            "debitAmount": "120.32",
+            "accountNumber": "93929393",
+        }
+        result = self.schema.load(data).data
+        assert result.amount == Decimal("120.32")
+        assert result.account_number == "93929393"
+
+    def test_missing_account_number_raises_validation_error(self):
+        data = {
+            "debitAmount": "383.20"
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "accountNumber" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["accountNumber"]
+
+    def test_missing_debit_amount_raises_validation_error(self):
+        data = {
+            "accountNumber": "93929393",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "debitAmount" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["debitAmount"]
+
+    def test_missing_all_fields_raises_validation_error(self):
+        data = {}
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "accountNumber" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["accountNumber"]
+        assert "debitAmount" in exc_info.value.messages
+        assert "Missing data for required field." in exc_info.value.messages["debitAmount"]
+
+    def test_additional_fields_are_ignored(self):
+        data = {
+            "debitAmount": "120.32",
+            "accountNumber": "93929393",
+            "additionalField": "value",
+        }
+        result = self.schema.load(data).data
+        assert result.amount == Decimal("120.32")
+        assert result.account_number == "93929393"
+
+
+@pytest.mark.tmp
+class TestBalanceSchema:
+    schema = balance_schema
+
+    def test_serializing_object_with_valid_balance(self):
+        balance = Decimal("8382.29")
+        result = self.schema.dump({"balance": balance}).data
+        assert result["balance"] == "8382.29"


### PR DESCRIPTION
Money should always be stored and represented as a decimal value rather
than integer or floats.